### PR TITLE
add js support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The latest demo app APK can be found in the [releases](https://github.com/Calvin
 
 ## Features
 
-- Supports Compose Multiplatform (Android, iOS, Desktop/JVM, Wasm)
+- Supports Compose Multiplatform (Android, iOS, Desktop/JVM, Wasm, JS)
 - Supports items of different sizes
 - Some items can be made non-reorderable
 - Supports dragging immediately or long press to start dragging

--- a/demoApp/composeApp/build.gradle.kts
+++ b/demoApp/composeApp/build.gradle.kts
@@ -29,6 +29,16 @@ kotlin {
         binaries.executable()
     }
 
+    js {
+        moduleName = "composeApp"
+        browser {
+            commonWebpackConfig {
+                outputFileName = "composeApp.js"
+            }
+        }
+        binaries.executable()
+    }
+
     listOf(
         iosX64(),
         iosArm64(),

--- a/demoApp/composeApp/src/jsMain/kotlin/main.kt
+++ b/demoApp/composeApp/src/jsMain/kotlin/main.kt
@@ -1,0 +1,13 @@
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.CanvasBasedWindow
+import org.jetbrains.skiko.wasm.onWasmReady
+import sh.calvin.reorderable.demo.ui.App
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+    onWasmReady {
+        CanvasBasedWindow(canvasElementId = "ComposeTarget") {
+            App()
+        }
+    }
+}

--- a/demoApp/composeApp/src/jsMain/kotlin/sh/calvin/reorderable/demo/haptics.js.kt
+++ b/demoApp/composeApp/src/jsMain/kotlin/sh/calvin/reorderable/demo/haptics.js.kt
@@ -1,0 +1,27 @@
+package sh.calvin.reorderable.demo
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import kotlinx.browser.window
+
+@Composable
+actual fun rememberReorderHapticFeedback(): ReorderHapticFeedback {
+    val reorderHapticFeedback = remember {
+        object : ReorderHapticFeedback() {
+            override fun performHapticFeedback(type: ReorderHapticFeedbackType) {
+                when (type) {
+                    ReorderHapticFeedbackType.START ->
+                        window.navigator.vibrate(5)
+
+                    ReorderHapticFeedbackType.MOVE ->
+                        window.navigator.vibrate(1)
+
+                    ReorderHapticFeedbackType.END ->
+                        window.navigator.vibrate(3)
+                }
+            }
+        }
+    }
+
+    return reorderHapticFeedback
+}

--- a/demoApp/composeApp/src/jsMain/resources/index.html
+++ b/demoApp/composeApp/src/jsMain/resources/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Compose App</title>
+    <script type="application/javascript" src="skiko.js"></script>
+  </head>
+  <body>
+    <canvas id="ComposeTarget"></canvas>
+    <script src="composeApp.js"></script>
+  </body>
+</html>

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,4 @@ SONATYPE_HOST=S01
 RELEASE_SIGNING_ENABLED=true
 
 org.jetbrains.compose.experimental.wasm.enabled=true
+org.jetbrains.compose.experimental.jscanvas.enabled=true

--- a/reorderable/build.gradle.kts
+++ b/reorderable/build.gradle.kts
@@ -28,6 +28,11 @@ kotlin {
         binaries.executable()
     }
 
+    js {
+        browser()
+        binaries.executable()
+    }
+
     listOf(
         iosX64(),
         iosArm64(),


### PR DESCRIPTION
Compose for Wasm doesn't work on Safari yet, so it's necessary to fall back to Compose JS Canvas. This PR adds a JS target so the library works with Compose JS.