### PR TITLE
fix jump effect error when drag item to top of the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,10 @@ var list by remember { mutableStateOf(List(100) { "Item $it" }) }
 val lazyListState = rememberLazyListState()
 val reorderableLazyListState = rememberReorderableLazyListState(lazyListState) { from, to ->
     list = list.toMutableList().apply {
-        add(to.index, removeAt(from.index))
+        val fromIndex = indexOfFirst { it == from.key }
+        val toIndex = indexOfFirst { it == to.key }
+
+        add(toIndex, removeAt(fromIndex))
     }
 
     view.performHapticFeedback(HapticFeedbackConstants.SEGMENT_FREQUENT_TICK)

--- a/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleReorderableLazyColumnScreen.kt
+++ b/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleReorderableLazyColumnScreen.kt
@@ -44,7 +44,10 @@ fun SimpleReorderableLazyColumnScreen() {
     val lazyListState = rememberLazyListState()
     val reorderableLazyColumnState = rememberReorderableLazyListState(lazyListState) { from, to ->
         list = list.toMutableList().apply {
-            add(to.index, removeAt(from.index))
+            val fromIndex = indexOfFirst { it == from.key }
+            val toIndex = indexOfFirst { it == to.key }
+
+            add(toIndex, removeAt(fromIndex))
         }
 
         haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)


### PR DESCRIPTION
Fix jump effect error when drag item to top of the list on example component SimpleReorderableLazyColumnScreen.

To reproduce the effect is only need to drag and drop some item to top of the list again.