### PR TITLE
Performance improvements for scroll

### DIFF
--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyCollection.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyCollection.kt
@@ -665,6 +665,7 @@ open class ReorderableLazyCollectionState<out T> internal constructor(
     }
 }
 
+@Stable
 interface ReorderableCollectionItemScope {
     /**
      * Make the UI element the draggable handle for the reorderable item.
@@ -830,11 +831,14 @@ internal fun ReorderableCollectionItem(
             itemPosition = it.positionInRoot()
         }
     ) {
-        ReorderableCollectionItemScopeImpl(
-            reorderableLazyCollectionState = state,
-            key = key,
-            itemPositionProvider = { itemPosition },
-        ).content(dragging)
+        val itemScope = remember(state, key) {
+            ReorderableCollectionItemScopeImpl(
+                reorderableLazyCollectionState = state,
+                key = key,
+                itemPositionProvider = { itemPosition },
+            )
+        }
+        itemScope.content(dragging)
     }
 
     LaunchedEffect(state.reorderableKeys, enabled) {

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyGrid.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyGrid.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.lazy.grid.LazyGridItemScope
 import androidx.compose.foundation.lazy.grid.LazyGridLayoutInfo
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -153,6 +154,7 @@ private fun LazyGridState.toLazyCollectionState() =
             this@toLazyCollectionState.scrollToItem(scrollToIndex, firstVisibleItemScrollOffset)
     }
 
+@Stable
 class ReorderableLazyGridState internal constructor(
     state: LazyGridState,
     scope: CoroutineScope,

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyList.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyList.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.lazy.LazyListItemInfo
 import androidx.compose.foundation.lazy.LazyListLayoutInfo
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -242,6 +243,7 @@ private fun LazyListState.toLazyCollectionState() =
             this@toLazyCollectionState.scrollToItem(scrollToIndex, firstVisibleItemScrollOffset)
     }
 
+@Stable
 class ReorderableLazyListState internal constructor(
     state: LazyListState,
     scope: CoroutineScope,

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyStaggeredGrid.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyStaggeredGrid.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridItemScope
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridLayoutInfo
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -152,6 +153,7 @@ private fun LazyStaggeredGridState.toLazyCollectionState() =
             this@toLazyCollectionState.scrollToItem(scrollToIndex, firstVisibleItemScrollOffset)
     }
 
+@Stable
 class ReorderableLazyStaggeredGridState internal constructor(
     state: LazyStaggeredGridState,
     scope: CoroutineScope,


### PR DESCRIPTION
Currently, on every scroll event, all items are being recomposed.  
This PR addresses this issue by:
- marking the State and Scope classes as `Stable`
- remembering the `ReorderableCollectionItemScopeImpl` instead of creating a new one