### PR TITLE
Extract drag detection logic to interface

### DIFF
--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/DragGestureDetector.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/DragGestureDetector.kt
@@ -1,0 +1,38 @@
+package sh.calvin.reorderable
+
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
+
+fun interface DragGestureDetector {
+    suspend fun PointerInputScope.detect(
+        onDragStart: (Offset) -> Unit,
+        onDragEnd: () -> Unit,
+        onDragCancel: () -> Unit,
+        onDrag: (change: PointerInputChange, dragAmount: Offset) -> Unit
+    )
+
+    object Normal: DragGestureDetector {
+        override suspend fun PointerInputScope.detect(
+            onDragStart: (Offset) -> Unit,
+            onDragEnd: () -> Unit,
+            onDragCancel: () -> Unit,
+            onDrag: (change: PointerInputChange, dragAmount: Offset) -> Unit
+        ) {
+            detectDragGestures(onDragStart, onDragEnd, onDragCancel, onDrag)
+        }
+    }
+
+    object LongPress: DragGestureDetector {
+        override suspend fun PointerInputScope.detect(
+            onDragStart: (Offset) -> Unit,
+            onDragEnd: () -> Unit,
+            onDragCancel: () -> Unit,
+            onDrag: (change: PointerInputChange, dragAmount: Offset) -> Unit
+        ) {
+            detectDragGesturesAfterLongPress(onDragStart, onDragEnd, onDragCancel, onDrag)
+        }
+    }
+}

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/DragGestureDetector.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/DragGestureDetector.kt
@@ -14,7 +14,7 @@ fun interface DragGestureDetector {
         onDrag: (change: PointerInputChange, dragAmount: Offset) -> Unit
     )
 
-    object Press: DragGestureDetector {
+    object Press : DragGestureDetector {
         override suspend fun PointerInputScope.detect(
             onDragStart: (Offset) -> Unit,
             onDragEnd: () -> Unit,
@@ -25,7 +25,7 @@ fun interface DragGestureDetector {
         }
     }
 
-    object LongPress: DragGestureDetector {
+    object LongPress : DragGestureDetector {
         override suspend fun PointerInputScope.detect(
             onDragStart: (Offset) -> Unit,
             onDragEnd: () -> Unit,

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/DragGestureDetector.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/DragGestureDetector.kt
@@ -14,7 +14,7 @@ fun interface DragGestureDetector {
         onDrag: (change: PointerInputChange, dragAmount: Offset) -> Unit
     )
 
-    object Normal: DragGestureDetector {
+    object Press: DragGestureDetector {
         override suspend fun PointerInputScope.detect(
             onDragStart: (Offset) -> Unit,
             onDragEnd: () -> Unit,

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyCollection.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyCollection.kt
@@ -653,6 +653,7 @@ interface ReorderableCollectionItemScope {
      *
      * This modifier can only be used on the UI element that is a child of [ReorderableItem].
      *
+     * @param dragGestureDetector [DragGestureDetector] that will be used to detect drag gestures
      * @param enabled Whether or not drag is enabled
      * @param interactionSource [MutableInteractionSource] that will be used to emit [DragInteraction.Start] when this draggable is being dragged.
      * @param onDragStarted The function that is called when the item starts being dragged
@@ -663,6 +664,7 @@ interface ReorderableCollectionItemScope {
         interactionSource: MutableInteractionSource? = null,
         onDragStarted: (startedPosition: Offset) -> Unit = {},
         onDragStopped: () -> Unit = {},
+        dragGestureDetector: DragGestureDetector = DragGestureDetector.Normal
     ): Modifier
 
     /**
@@ -701,7 +703,8 @@ internal class ReorderableCollectionItemScopeImpl(
         interactionSource: MutableInteractionSource?,
         onDragStarted: (startedPosition: Offset) -> Unit,
         onDragStopped: () -> Unit,
-    ) = composed {
+        dragGestureDetector: DragGestureDetector
+    ): Modifier = composed {
         var handleOffset by remember { mutableStateOf(Offset.Zero) }
         var handleSize by remember { mutableStateOf(IntSize.Zero) }
 
@@ -714,6 +717,7 @@ internal class ReorderableCollectionItemScopeImpl(
             key1 = reorderableLazyCollectionState,
             enabled = enabled && (reorderableLazyCollectionState.isItemDragging(key).value || !reorderableLazyCollectionState.isAnyItemDragging),
             interactionSource = interactionSource,
+            dragGestureDetector = dragGestureDetector,
             onDragStarted = {
                 coroutineScope.launch {
                     val handleOffsetRelativeToItem = handleOffset - itemPositionProvider()
@@ -733,7 +737,7 @@ internal class ReorderableCollectionItemScopeImpl(
             onDrag = { change, dragAmount ->
                 change.consume()
                 reorderableLazyCollectionState.onDrag(dragAmount)
-            },
+            }
         )
     }
 
@@ -750,41 +754,14 @@ internal class ReorderableCollectionItemScopeImpl(
         interactionSource: MutableInteractionSource?,
         onDragStarted: (startedPosition: Offset) -> Unit,
         onDragStopped: () -> Unit,
-    ) = composed {
-        var handleOffset by remember { mutableStateOf(Offset.Zero) }
-        var handleSize by remember { mutableStateOf(IntSize.Zero) }
-
-        val coroutineScope = rememberCoroutineScope()
-
-        onGloballyPositioned {
-            handleOffset = it.positionInRoot()
-            handleSize = it.size
-        }.longPressDraggable(
-            key1 = reorderableLazyCollectionState,
-            enabled = enabled && (reorderableLazyCollectionState.isItemDragging(key).value || !reorderableLazyCollectionState.isAnyItemDragging),
+    ) =
+        draggableHandle(
+            enabled = enabled,
             interactionSource = interactionSource,
-            onDragStarted = {
-                coroutineScope.launch {
-                    val handleOffsetRelativeToItem = handleOffset - itemPositionProvider()
-                    val handleCenter = Offset(
-                        handleOffsetRelativeToItem.x + handleSize.width / 2f,
-                        handleOffsetRelativeToItem.y + handleSize.height / 2f
-                    )
-
-                    reorderableLazyCollectionState.onDragStart(key, handleCenter)
-                }
-                onDragStarted(it)
-            },
-            onDragStopped = {
-                reorderableLazyCollectionState.onDragStop()
-                onDragStopped()
-            },
-            onDrag = { change, dragAmount ->
-                change.consume()
-                reorderableLazyCollectionState.onDrag(dragAmount)
-            },
+            onDragStarted = onDragStarted,
+            onDragStopped = onDragStopped,
+            dragGestureDetector = DragGestureDetector.LongPress
         )
-    }
 }
 
 /**

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyCollection.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyCollection.kt
@@ -664,7 +664,7 @@ interface ReorderableCollectionItemScope {
         interactionSource: MutableInteractionSource? = null,
         onDragStarted: (startedPosition: Offset) -> Unit = {},
         onDragStopped: () -> Unit = {},
-        dragGestureDetector: DragGestureDetector = DragGestureDetector.Normal
+        dragGestureDetector: DragGestureDetector = DragGestureDetector.Press
     ): Modifier
 
     /**

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyCollection.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyCollection.kt
@@ -653,11 +653,11 @@ interface ReorderableCollectionItemScope {
      *
      * This modifier can only be used on the UI element that is a child of [ReorderableItem].
      *
-     * @param dragGestureDetector [DragGestureDetector] that will be used to detect drag gestures
      * @param enabled Whether or not drag is enabled
      * @param interactionSource [MutableInteractionSource] that will be used to emit [DragInteraction.Start] when this draggable is being dragged.
      * @param onDragStarted The function that is called when the item starts being dragged
      * @param onDragStopped The function that is called when the item stops being dragged
+     * @param dragGestureDetector [DragGestureDetector] that will be used to detect drag gestures
      */
     fun Modifier.draggableHandle(
         enabled: Boolean = true,

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableList.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableList.kt
@@ -204,11 +204,11 @@ interface ReorderableScope {
     /**
      * Make the UI element the draggable handle for the reorderable item.
      *
-     * @param dragGestureDetector [DragGestureDetector] that will be used to detect drag gestures
      * @param enabled Whether or not drag is enabled
      * @param interactionSource [MutableInteractionSource] that will be used to emit [DragInteraction.Start] when this draggable is being dragged
      * @param onDragStarted The function that is called when the item starts being dragged
      * @param onDragStopped The function that is called when the item stops being dragged
+     * @param dragGestureDetector [DragGestureDetector] that will be used to detect drag gestures
      */
     fun Modifier.draggableHandle(
         enabled: Boolean = true,

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableList.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableList.kt
@@ -215,7 +215,7 @@ interface ReorderableScope {
         onDragStarted: (startedPosition: Offset) -> Unit = {},
         onDragStopped: (velocity: Float) -> Unit = {},
         interactionSource: MutableInteractionSource? = null,
-        dragGestureDetector: DragGestureDetector = DragGestureDetector.Normal
+        dragGestureDetector: DragGestureDetector = DragGestureDetector.Press
     ): Modifier
 
     /**

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/draggable.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/draggable.kt
@@ -1,7 +1,5 @@
 package sh.calvin.reorderable
 
-import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.interaction.DragInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.DisposableEffect
@@ -21,6 +19,7 @@ internal fun Modifier.draggable(
     key1: Any?,
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource? = null,
+    dragGestureDetector: DragGestureDetector = DragGestureDetector.Normal,
     onDragStarted: (Offset) -> Unit = { },
     onDragStopped: () -> Unit = { },
     onDrag: (change: PointerInputChange, dragAmount: Offset) -> Unit,
@@ -48,8 +47,12 @@ internal fun Modifier.draggable(
     }
 
     pointerInput(key1, enabled) {
-        if (enabled) {
-            detectDragGestures(
+        if (!enabled) {
+            return@pointerInput
+        }
+
+        with(dragGestureDetector) {
+            detect(
                 onDragStart = {
                     dragStarted = true
                     dragInteractionStart = DragInteraction.Start().also {
@@ -85,83 +88,6 @@ internal fun Modifier.draggable(
                     }
 
                     dragStarted = false
-                },
-                onDrag = onDrag,
-            )
-        }
-    }
-}
-
-internal fun Modifier.longPressDraggable(
-    key1: Any?,
-    enabled: Boolean = true,
-    interactionSource: MutableInteractionSource? = null,
-    onDragStarted: (Offset) -> Unit = { },
-    onDragStopped: () -> Unit = { },
-    onDrag: (change: PointerInputChange, dragAmount: Offset) -> Unit,
-) = composed {
-    val coroutineScope = rememberCoroutineScope()
-    var dragInteractionStart by remember { mutableStateOf<DragInteraction.Start?>(null) }
-    var dragStarted by remember { mutableStateOf(false) }
-
-    DisposableEffect(key1) {
-        onDispose {
-            if (dragStarted) {
-                dragInteractionStart?.also {
-                    coroutineScope.launch {
-                        interactionSource?.emit(DragInteraction.Cancel(it))
-                    }
-                }
-
-                if (dragStarted) {
-                    onDragStopped()
-                }
-
-                dragStarted = false
-            }
-        }
-    }
-
-    pointerInput(key1, enabled) {
-        if (enabled) {
-            detectDragGesturesAfterLongPress(
-                onDragStart = {
-                    dragStarted = true
-                    dragInteractionStart = DragInteraction.Start().also {
-                        coroutineScope.launch {
-                            interactionSource?.emit(it)
-                        }
-                    }
-
-                    onDragStarted(it)
-                },
-                onDragEnd = {
-                    dragInteractionStart?.also {
-                        coroutineScope.launch {
-                            interactionSource?.emit(DragInteraction.Stop(it))
-                        }
-                    }
-
-                    if (dragStarted) {
-                        onDragStopped()
-                    }
-
-                    dragStarted = false
-
-                },
-                onDragCancel = {
-                    dragInteractionStart?.also {
-                        coroutineScope.launch {
-                            interactionSource?.emit(DragInteraction.Cancel(it))
-                        }
-                    }
-
-                    if (dragStarted) {
-                        onDragStopped()
-                    }
-
-                    dragStarted = false
-
                 },
                 onDrag = onDrag,
             )

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/draggable.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/draggable.kt
@@ -19,7 +19,7 @@ internal fun Modifier.draggable(
     key1: Any?,
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource? = null,
-    dragGestureDetector: DragGestureDetector = DragGestureDetector.Normal,
+    dragGestureDetector: DragGestureDetector = DragGestureDetector.Press,
     onDragStarted: (Offset) -> Unit = { },
     onDragStopped: () -> Unit = { },
     onDrag: (change: PointerInputChange, dragAmount: Offset) -> Unit,


### PR DESCRIPTION
Currently, only two hardcoded types of dragging (press and long press) are supported by this library. 

This PR adds an interface, `DragGestureDetector`, which is responsible for handling drag detection via `PointerInputScope`. The interface is taken as a parameter in drag handle functions such as `draggableHandle`, allowing the user to override the behaviour. This is useful for applications that wish to use non-standard drag detection, such as dragging with middle click or waiting for a long press using a specific length.

API changes (let me know if you'd rather these were reverted):
- `draggableHandle` methods now have a `dragGestureDetector` parameter in the last position (with a default value)
- The `onDragStarted` and `onDragStopped` parameters of `ReorderableScope.draggableHandle` are no longer suspending and do not have `CoroutineScope` as a receiver

The `longPressDraggableHandle` API is kept the same, but now just calls `draggableHandle` with `DragGestureDetector.LongPress` as the `dragGestureDetector`.