### PR TITLE
Snaps dragged item to end of collection if dragged past bounds

### DIFF
--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyCollection.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyCollection.kt
@@ -280,8 +280,10 @@ open class ReorderableLazyCollectionState<out T> internal constructor(
      * A function that determines whether the `draggingItem` should be moved with the `item`.
      * Given their bounding rectangles, return `true` if they should be moved.
      * The default implementation is to move if the dragging item's bounding rectangle has crossed the center of the item's bounding rectangle.
+     * It also provides additional parameters for snapping `draggingItem` to the last spot if it's dragged
+     * into empty space beyond the end of the collection.
      */
-    private val shouldItemMove: (draggingItem: Rect, item: Rect) -> Boolean = { draggingItem, item ->
+    private val shouldItemMove: (draggingItem: Rect, item: Rect, itemIndex: Int, maxIndex: Int) -> Boolean = { draggingItem, item, _, _ ->
         draggingItem.contains(item.center)
     },
 ) : ReorderableLazyCollectionStateInterface {
@@ -596,10 +598,15 @@ open class ReorderableLazyCollectionState<out T> internal constructor(
         direction: Scroller.Direction = Scroller.Direction.FORWARD,
         additionalPredicate: (LazyCollectionItemInfo<T>) -> Boolean = { true },
     ): LazyCollectionItemInfo<T>? {
+        // Although this is computed to handle the edge case of dragging an item to an empty spot
+        // at the end of a collection, it suffices to only get the max index of any visible item. If
+        // the collection is not scrolled all the way to the end, then there is no empty collection
+        // spots, and the behavior does not change.
+        val maxIndex = state.layoutInfo.visibleItemsInfo.maxOf { it.index }
         val targetItemFunc = { item: LazyCollectionItemInfo<T> ->
             val targetItemRect = Rect(item.offset.toOffset(), item.size.toSize())
 
-            shouldItemMove(draggingItemRect, targetItemRect)
+            shouldItemMove(draggingItemRect, targetItemRect, item.index, maxIndex)
                     && item.key in reorderableKeys
                     && additionalPredicate(item)
         }

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyGrid.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyGrid.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -172,6 +173,16 @@ class ReorderableLazyGridState internal constructor(
     scroller: Scroller,
     scrollMoveMode: ScrollMoveMode,
     layoutDirection: LayoutDirection,
+    shouldItemMove: (Rect, Rect, Int, Int) -> Boolean = { draggingItem, item, itemIndex, maxIndex ->
+        // If the item being compared with is the last index in the collection, also move
+        // if the current `draggable` is 'past' the last item along both axes.
+        val isLastItem = itemIndex == maxIndex
+        if (isLastItem) {
+            (draggingItem.top > item.top && draggingItem.left > item.left) || draggingItem.contains(item.center)
+        } else {
+            draggingItem.contains(item.center)
+        }
+    }
 ) : ReorderableLazyCollectionState<LazyGridItemInfo>(
     state.toLazyCollectionState(),
     scope,
@@ -181,6 +192,7 @@ class ReorderableLazyGridState internal constructor(
     scroller,
     scrollMoveMode,
     layoutDirection,
+    shouldItemMove = shouldItemMove
 )
 
 /**

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyList.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyList.kt
@@ -175,12 +175,22 @@ fun rememberReorderableLazyListState(
             scroller = scroller,
             layoutDirection = layoutDirection,
             shouldItemMove = when (orientation) {
-                Orientation.Vertical -> { draggingItem, item ->
-                    item.center.y in draggingItem.top..<draggingItem.bottom
+                Orientation.Vertical -> { draggingItem, item, itemIndex, maxIndex ->
+                    val isLastItem = itemIndex == maxIndex
+                    if (isLastItem) {
+                        draggingItem.top > item.top || item.center.y in draggingItem.top..<draggingItem.bottom
+                    } else {
+                        item.center.y in draggingItem.top..<draggingItem.bottom
+                    }
                 }
 
-                Orientation.Horizontal -> { draggingItem, item ->
-                    item.center.x in draggingItem.left..<draggingItem.right
+                Orientation.Horizontal -> { draggingItem, item, itemIndex, maxIndex ->
+                    val isLastItem = itemIndex == maxIndex
+                    if (isLastItem) {
+                        draggingItem.left > item.left || item.center.x in draggingItem.left..<draggingItem.right
+                    } else {
+                        item.center.x in draggingItem.left..<draggingItem.right
+                    }
                 }
             },
         )
@@ -257,7 +267,7 @@ class ReorderableLazyListState internal constructor(
     scrollThresholdPadding: AbsolutePixelPadding,
     scroller: Scroller,
     layoutDirection: LayoutDirection,
-    shouldItemMove: (draggingItem: Rect, item: Rect) -> Boolean,
+    shouldItemMove: (draggingItem: Rect, item: Rect, itemIndex: Int, maxIndex: Int) -> Boolean,
 ) : ReorderableLazyCollectionState<LazyListItemInfo>(
     state.toLazyCollectionState(),
     scope,


### PR DESCRIPTION
This is most applicable for grids and corresponds with issue #118.

If the number of items in a grid is not a perfect multiple of the column/row count, then there can be empty slots at the end of a grid. For example, with 8 items and 3 rows, the layout is:

```
0 1 2
3 4 5
6 7
```
In this situation, if the user drags 5 straight down, their intent is likely to move it to the end of the grid, but because the center of 5 is never contained with 7, the code to swap them never runs. Alternately, if the margin between items is big enough, it's not that difficult to drag 4 diagonally between 5 and 7 and have the same issue.

Because there's no way to get the full number of items in the collection without introducing a breaking API change, my code uses `state.layoutInfo.visibleItemsInfo.maxOf { it.index }` instead to get the highest currently rendered item. This is safe because if the current view doesn't include the end of the grid, then there's no empty spots and no behavior change.

This is my first contribution to another open source library, so please let me know if there's anything else you want me to do!