### PR TITLE
Fix ReorderableRow arrangement parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1441,7 +1441,7 @@ ReorderableColumn(
             HapticFeedbackConstantsCompat.SEGMENT_FREQUENT_TICK
         )
     },
-    verticalArrangement = Arrangement.spacedBy(8.dp),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
 ) { _, item, isDragging ->
     key(item) {
         ReorderableItem {
@@ -1619,7 +1619,7 @@ ReorderableRow(
             HapticFeedbackConstantsCompat.SEGMENT_FREQUENT_TICK
         )
     },
-    verticalArrangement = Arrangement.spacedBy(8.dp),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
 ) { _, item, isDragging ->
     key(item) {
         ReorderableItem {
@@ -1710,7 +1710,7 @@ ReorderableRow(
             HapticFeedbackConstantsCompat.SEGMENT_FREQUENT_TICK
         )
     },
-    verticalArrangement = Arrangement.spacedBy(8.dp),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
 ) { _, item, _ ->
     key(item) {
         ReorderableItem {


### PR DESCRIPTION
## Summary
- Correct `ReorderableRow` README examples to use `horizontalArrangement` instead of `verticalArrangement`
- Matches the actual `ReorderableRow` API and demo app usage

## Test plan
- [x] Documentation-only change; verified against `ReorderableRow` signature in `ReorderableList.kt`