### PR TITLE
Suppress known KMP build warnings on non-macOS hosts

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,7 @@ signAllPublications=true
 org.jetbrains.compose.experimental.wasm.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
+
+# Suppress known Kotlin Multiplatform warnings on non-macOS hosts and with newer AGP
+kotlin.native.ignoreDisabledTargets=true
+kotlin.mpp.androidGradlePluginCompatibility.nowarn=true


### PR DESCRIPTION
## Summary
- Add `kotlin.native.ignoreDisabledTargets=true` to silence iOS/macOS target warnings on Windows/Linux
- Add `kotlin.mpp.androidGradlePluginCompatibility.nowarn=true` for the known AGP 8.8 / KGP compatibility notice

## Test plan
- [x] `:reorderable:compileKotlinJvm` succeeds without the disabled-target and AGP compatibility warnings