### PR TITLE
Add option to disable swap for defined elements

### DIFF
--- a/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/ComplexReorderableLazyColumnScreen.kt
+++ b/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/ComplexReorderableLazyColumnScreen.kt
@@ -54,6 +54,7 @@ fun ComplexReorderableLazyColumnScreen() {
         }
 
         haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
+        true
     }
 
     LazyColumn(

--- a/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/ComplexReorderableLazyRowScreen.kt
+++ b/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/ComplexReorderableLazyRowScreen.kt
@@ -54,6 +54,7 @@ fun ComplexReorderableLazyRowScreen() {
         }
 
         haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
+        true
     }
 
     LazyRow(

--- a/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleLongPressHandleReorderableLazyColumnScreen.kt
+++ b/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleLongPressHandleReorderableLazyColumnScreen.kt
@@ -46,6 +46,7 @@ fun SimpleLongPressHandleReorderableLazyColumnScreen() {
         }
 
         haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
+        true
     }
 
     LazyColumn(

--- a/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleReorderableLazyColumnScreen.kt
+++ b/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleReorderableLazyColumnScreen.kt
@@ -46,6 +46,7 @@ fun SimpleReorderableLazyColumnScreen() {
         }
 
         haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
+        true
     }
 
     LazyColumn(

--- a/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleReorderableLazyHorizontalGridScreen.kt
+++ b/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleReorderableLazyHorizontalGridScreen.kt
@@ -50,6 +50,7 @@ fun SimpleReorderableLazyHorizontalGridScreen() {
         }
 
         haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
+        true
     }
 
     LazyHorizontalGrid(

--- a/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleReorderableLazyHorizontalStaggeredGridScreen.kt
+++ b/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleReorderableLazyHorizontalStaggeredGridScreen.kt
@@ -51,6 +51,7 @@ fun SimpleReorderableLazyHorizontalStaggeredGridScreen() {
             }
 
             haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
+            true
         }
 
     LazyHorizontalStaggeredGrid(

--- a/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleReorderableLazyRowScreen.kt
+++ b/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleReorderableLazyRowScreen.kt
@@ -47,6 +47,7 @@ fun SimpleReorderableLazyRowScreen() {
         }
 
         haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
+        true
     }
 
     LazyRow(

--- a/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleReorderableLazyVerticalGridScreen.kt
+++ b/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleReorderableLazyVerticalGridScreen.kt
@@ -50,6 +50,7 @@ fun SimpleReorderableLazyVerticalGridScreen() {
         }
 
         haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
+        true
     }
 
     LazyVerticalGrid(

--- a/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleReorderableLazyVerticalStaggeredGridScreen.kt
+++ b/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/SimpleReorderableLazyVerticalStaggeredGridScreen.kt
@@ -51,6 +51,7 @@ fun SimpleReorderableLazyVerticalStaggeredGridScreen() {
             }
 
             haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
+            true
         }
 
     LazyVerticalStaggeredGrid(

--- a/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/TwoReorderableLazyColumnScreen.kt
+++ b/demoApp/composeApp/src/commonMain/kotlin/sh/calvin/reorderable/demo/ui/TwoReorderableLazyColumnScreen.kt
@@ -57,6 +57,7 @@ fun TwoReorderableLazyColumnScreen() {
         list2 = combinedList.slice(3..5)
 
         haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
+        true
     }
 
     LazyColumn(

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyCollection.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyCollection.kt
@@ -62,6 +62,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.milliseconds
 
 object ReorderableLazyCollectionDefaults {
     val ScrollThreshold = 48.dp
@@ -257,7 +258,7 @@ enum class ScrollMoveMode {
 open class ReorderableLazyCollectionState<out T> internal constructor(
     private val state: LazyCollectionState<T>,
     private val scope: CoroutineScope,
-    private val onMoveState: State<suspend CoroutineScope.(from: T, to: T) -> Unit>,
+    private val onMoveState: State<suspend CoroutineScope.(from: T, to: T) -> Boolean>,
 
     /**
      * The threshold in pixels for scrolling the list when dragging an item.
@@ -640,15 +641,15 @@ open class ReorderableLazyCollectionState<out T> internal constructor(
 
                 oldDraggingItemIndex = draggingItem.index
 
-                scope.(onMoveState.value)(draggingItem.data, targetItem.data)
-
-                predictedDraggingItemOffset = if (targetItem.index > draggingItem.index) {
-                    (targetItem.offset + targetItem.size) - draggingItem.size
-                } else {
-                    targetItem.offset
+                if (scope.(onMoveState.value)(draggingItem.data, targetItem.data)) {
+                    predictedDraggingItemOffset = if (targetItem.index > draggingItem.index) {
+                        (targetItem.offset + targetItem.size) - draggingItem.size
+                    } else {
+                        targetItem.offset
+                    }
                 }
 
-                withTimeout(MoveItemsLayoutInfoUpdateMaxWaitDuration) {
+                withTimeout(MoveItemsLayoutInfoUpdateMaxWaitDuration.milliseconds) {
                     // the first result from layoutInfoFlow is the current layoutInfo
                     // the second result is the updated layoutInfo
                     layoutInfoFlow.take(2).collect()

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyGrid.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyGrid.kt
@@ -67,7 +67,7 @@ fun rememberReorderableLazyGridState(
         pixelAmountProvider = { lazyGridState.layoutInfo.mainAxisViewportSize * ScrollAmountMultiplier },
     ),
     scrollMoveMode: ScrollMoveMode = ScrollMoveMode.SWAP,
-    onMove: suspend CoroutineScope.(from: LazyGridItemInfo, to: LazyGridItemInfo) -> Unit,
+    onMove: suspend CoroutineScope.(from: LazyGridItemInfo, to: LazyGridItemInfo) -> Boolean,
 ): ReorderableLazyGridState {
     val density = LocalDensity.current
     val scrollThresholdPx = with(density) { scrollThreshold.toPx() }
@@ -160,7 +160,7 @@ private fun LazyGridState.toLazyCollectionState() =
 class ReorderableLazyGridState internal constructor(
     state: LazyGridState,
     scope: CoroutineScope,
-    onMoveState: State<suspend CoroutineScope.(from: LazyGridItemInfo, to: LazyGridItemInfo) -> Unit>,
+    onMoveState: State<suspend CoroutineScope.(from: LazyGridItemInfo, to: LazyGridItemInfo) -> Boolean>,
 
     /**
      * The threshold in pixels for scrolling the grid when dragging an item.

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyList.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyList.kt
@@ -74,7 +74,7 @@ fun rememberReorderableLazyColumnState(
         scrollableState = lazyListState,
         pixelAmountProvider = { lazyListState.layoutInfo.mainAxisViewportSize * ScrollAmountMultiplier },
     ),
-    onMove: suspend CoroutineScope.(from: LazyListItemInfo, to: LazyListItemInfo) -> Unit,
+    onMove: suspend CoroutineScope.(from: LazyListItemInfo, to: LazyListItemInfo) -> Boolean,
 ) = rememberReorderableLazyListState(
     lazyListState,
     scrollThresholdPadding,
@@ -110,7 +110,7 @@ fun rememberReorderableLazyRowState(
         scrollableState = lazyListState,
         pixelAmountProvider = { lazyListState.layoutInfo.mainAxisViewportSize * ScrollAmountMultiplier },
     ),
-    onMove: suspend CoroutineScope.(from: LazyListItemInfo, to: LazyListItemInfo) -> Unit,
+    onMove: suspend CoroutineScope.(from: LazyListItemInfo, to: LazyListItemInfo) -> Boolean,
 ) = rememberReorderableLazyListState(
     lazyListState,
     scrollThresholdPadding,
@@ -139,7 +139,7 @@ fun rememberReorderableLazyListState(
         scrollableState = lazyListState,
         pixelAmountProvider = { lazyListState.layoutInfo.mainAxisViewportSize * ScrollAmountMultiplier },
     ),
-    onMove: suspend CoroutineScope.(from: LazyListItemInfo, to: LazyListItemInfo) -> Unit,
+    onMove: suspend CoroutineScope.(from: LazyListItemInfo, to: LazyListItemInfo) -> Boolean,
 ): ReorderableLazyListState {
     val density = LocalDensity.current
     val scrollThresholdPx = with(density) { scrollThreshold.toPx() }
@@ -246,7 +246,7 @@ private fun LazyListState.toLazyCollectionState() =
 class ReorderableLazyListState internal constructor(
     state: LazyListState,
     scope: CoroutineScope,
-    onMoveState: State<suspend CoroutineScope.(from: LazyListItemInfo, to: LazyListItemInfo) -> Unit>,
+    onMoveState: State<suspend CoroutineScope.(from: LazyListItemInfo, to: LazyListItemInfo) -> Boolean>,
 
     /**
      * The threshold in pixels for scrolling the list when dragging an item.

--- a/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyStaggeredGrid.kt
+++ b/reorderable/src/commonMain/kotlin/sh/calvin/reorderable/ReorderableLazyStaggeredGrid.kt
@@ -67,7 +67,7 @@ fun rememberReorderableLazyStaggeredGridState(
         pixelAmountProvider = { lazyStaggeredGridState.layoutInfo.mainAxisViewportSize * ScrollAmountMultiplier },
     ),
     scrollMoveMode: ScrollMoveMode = ScrollMoveMode.SWAP,
-    onMove: suspend CoroutineScope.(from: LazyStaggeredGridItemInfo, to: LazyStaggeredGridItemInfo) -> Unit,
+    onMove: suspend CoroutineScope.(from: LazyStaggeredGridItemInfo, to: LazyStaggeredGridItemInfo) -> Boolean,
 ): ReorderableLazyStaggeredGridState {
     val density = LocalDensity.current
     val scrollThresholdPx = with(density) { scrollThreshold.toPx() }
@@ -159,7 +159,7 @@ private fun LazyStaggeredGridState.toLazyCollectionState() =
 class ReorderableLazyStaggeredGridState internal constructor(
     state: LazyStaggeredGridState,
     scope: CoroutineScope,
-    onMoveState: State<suspend CoroutineScope.(from: LazyStaggeredGridItemInfo, to: LazyStaggeredGridItemInfo) -> Unit>,
+    onMoveState: State<suspend CoroutineScope.(from: LazyStaggeredGridItemInfo, to: LazyStaggeredGridItemInfo) -> Boolean>,
 
     /**
      * The threshold in pixels for scrolling the grid when dragging an item.


### PR DESCRIPTION
Our project have sections in the lazy column and it is not allowed to move items to another section. I changed the definition of onMove method so it returns a boolean to avoid offset calculation when the item move is blocked.